### PR TITLE
ci(test.yml): Remove Node v23 from test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false # Do not stop other jobs if one fails
       matrix:
-        version: [20, 22, 23, 24]
+        version: [20, 22, 24]
         os: [ubuntu-24.04, windows-2025, macos-15]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Node v23 has reached end of life.
<img width="760" alt="nodev23" src="https://github.com/user-attachments/assets/5427d6b6-dbd9-48c2-9503-f8c31a811ecf" />

https://nodejs.org/en/about/previous-releases
