### PR TITLE
refactor: Align arguments between addLintingMessage & addLintingMessages

### DIFF
--- a/src/autofix/autofix.ts
+++ b/src/autofix/autofix.ts
@@ -269,7 +269,7 @@ async function autofixJs(
 			if (err instanceof Error) {
 				log.verbose(`Error while applying autofix to ${resourcePath}: ${err}`);
 				log.verbose(`Call stack: ${err.stack}`);
-				context.addLintingMessage(resourcePath, MESSAGE.AUTOFIX_ERROR, {message: err.message});
+				context.addLintingMessage(resourcePath, {id: MESSAGE.AUTOFIX_ERROR, args: {message: err.message}});
 				continue;
 			}
 			throw err;
@@ -314,7 +314,7 @@ async function autofixJs(
 				log.verbose(message);
 				log.verbose(errors);
 				log.verbose(resourcePath + ":\n" + contentWithMarkers.join("\n"));
-				context.addLintingMessage(resourcePath, MESSAGE.AUTOFIX_ERROR, {message});
+				context.addLintingMessage(resourcePath, {id: MESSAGE.AUTOFIX_ERROR, args: {message}});
 			} else {
 				log.verbose(`Autofix applied to ${resourcePath}`);
 				res.set(resourcePath, newContent);
@@ -362,7 +362,7 @@ async function autofixXml(
 				contentWithMarkers.splice(markerLine, 0, leadingTabs + " ".repeat(newXmlError.col - tabCount) + "^");
 			}
 			log.verbose(resourcePath + ":\n" + contentWithMarkers.join("\n"));
-			context.addLintingMessage(resourcePath, MESSAGE.AUTOFIX_ERROR, {message});
+			context.addLintingMessage(resourcePath, {id: MESSAGE.AUTOFIX_ERROR, args: {message}});
 			continue;
 		}
 		log.verbose(`Autofix applied to ${resourcePath}`);
@@ -385,7 +385,7 @@ async function autofixHtml(
 			if (err instanceof Error) {
 				log.verbose(`Error while applying autofix to ${resourcePath}: ${err}`);
 				log.verbose(`Call stack: ${err.stack}`);
-				context.addLintingMessage(resourcePath, MESSAGE.AUTOFIX_ERROR, {message: err.message});
+				context.addLintingMessage(resourcePath, {id: MESSAGE.AUTOFIX_ERROR, args: {message: err.message}});
 				continue;
 			}
 			throw err;

--- a/src/linter/LinterContext.ts
+++ b/src/linter/LinterContext.ts
@@ -29,7 +29,7 @@ export interface RawLintResult {
 
 export interface RawLintMessage<M extends MESSAGE = MESSAGE> {
 	id: M;
-	args: MessageArgs[M];
+	args?: MessageArgs[M];
 	position?: PositionInfo;
 	fix?: Fix;
 	ui5TypeInfo?: Ui5TypeInfo;
@@ -238,13 +238,13 @@ export default class LinterContext {
 			severity: messageInfo.severity,
 			line: rawMessage.position ? rawMessage.position.line : undefined,
 			column: rawMessage.position ? rawMessage.position.column : undefined,
-			message: messageFunc(rawMessage.args || {}),
+			message: messageFunc(rawMessage.args ?? {} as MessageArgs[M]),
 			ui5TypeInfo: rawMessage.ui5TypeInfo,
 		};
 
 		if (this.#includeMessageDetails) {
 			const detailsFunc = messageInfo.details as (args: MessageArgs[M]) => string | undefined;
-			const messageDetails = detailsFunc(rawMessage.args || {});
+			const messageDetails = detailsFunc(rawMessage.args ?? {} as MessageArgs[M]);
 			if (messageDetails) {
 				message.messageDetails = resolveLinks(messageDetails);
 			}

--- a/src/linter/LinterContext.ts
+++ b/src/linter/LinterContext.ts
@@ -193,9 +193,9 @@ export default class LinterContext {
 	}
 
 	addLintingMessage<M extends MESSAGE>(
-		resourcePath: ResourcePath, id: M, args: MessageArgs[M], position?: PositionInfo, fix?: Fix
+		resourcePath: ResourcePath, rawMessage: RawLintMessage<M>
 	): void {
-		this.getRawLintingMessages(resourcePath).push({id, args, position, fix});
+		this.getRawLintingMessages(resourcePath).push(rawMessage);
 	}
 
 	addLintingMessages<M extends MESSAGE>(

--- a/src/linter/binding/BindingLinter.ts
+++ b/src/linter/binding/BindingLinter.ts
@@ -154,10 +154,10 @@ export default class BindingLinter {
 		if (!variableName) {
 			return;
 		}
-		this.#context.addLintingMessage(this.#resourcePath, MESSAGE.NO_GLOBALS, {
+		this.#context.addLintingMessage(this.#resourcePath, {id: MESSAGE.NO_GLOBALS, args: {
 			variableName,
 			namespace: ref,
-		}, position);
+		}, position});
 	}
 
 	getGlobalReference(ref: string, requireDeclarations: RequireDeclaration[]): string | null {
@@ -272,7 +272,7 @@ export default class BindingLinter {
 						decl.moduleName === expectedModuleName || decl.moduleName === ODATA_EXPRESSION_ADDONS_MODULE)
 				) {
 					this.#context.addLintingMessage(
-						this.#resourcePath, MESSAGE.NO_ODATA_GLOBALS, {} as never, position
+						this.#resourcePath, {id: MESSAGE.NO_ODATA_GLOBALS, args: {} as never, position}
 					);
 				}
 			}
@@ -281,6 +281,6 @@ export default class BindingLinter {
 	}
 
 	reportParsingError(message: string, position: PositionInfo) {
-		this.#context.addLintingMessage(this.#resourcePath, MESSAGE.PARSING_ERROR, {message}, position);
+		this.#context.addLintingMessage(this.#resourcePath, {id: MESSAGE.PARSING_ERROR, args: {message}, position});
 	}
 }

--- a/src/linter/binding/BindingLinter.ts
+++ b/src/linter/binding/BindingLinter.ts
@@ -272,7 +272,7 @@ export default class BindingLinter {
 						decl.moduleName === expectedModuleName || decl.moduleName === ODATA_EXPRESSION_ADDONS_MODULE)
 				) {
 					this.#context.addLintingMessage(
-						this.#resourcePath, {id: MESSAGE.NO_ODATA_GLOBALS, args: {} as never, position}
+						this.#resourcePath, {id: MESSAGE.NO_ODATA_GLOBALS, position}
 					);
 				}
 			}

--- a/src/linter/dotLibrary/DotLibraryLinter.ts
+++ b/src/linter/dotLibrary/DotLibraryLinter.ts
@@ -22,7 +22,7 @@ export default class DotLibraryLinter {
 			this.#analyzeDeprecatedLibs(dotLibraryDependencyTags);
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
-			this.#context.addLintingMessage(this.#resourcePath, MESSAGE.PARSING_ERROR, {message});
+			this.#context.addLintingMessage(this.#resourcePath, {id: MESSAGE.PARSING_ERROR, args: {message}});
 		}
 	}
 
@@ -65,11 +65,13 @@ export default class DotLibraryLinter {
 			if (deprecatedLibraries.includes(libraryName)) {
 				this.#context.addLintingMessage(
 					this.#resourcePath,
-					MESSAGE.DEPRECATED_LIBRARY,
-					{libraryName},
 					{
-						line: lib.openStart.line + 1,
-						column: lib.openStart.character + 1,
+						id: MESSAGE.DEPRECATED_LIBRARY,
+						args: {libraryName},
+						position: {
+							line: lib.openStart.line + 1,
+							column: lib.openStart.character + 1,
+						},
 					}
 				);
 			}

--- a/src/linter/fileTypes/linter.ts
+++ b/src/linter/fileTypes/linter.ts
@@ -15,6 +15,6 @@ export default async function lintFileTypes({filePathsWorkspace, context}: Linte
 
 	potentialDeprecatedResources.forEach((resource: Resource) => {
 		const fileSuffix = resource.getPath().split(".").pop()!.toUpperCase();
-		context.addLintingMessage(resource.getPath(), MESSAGE.DEPRECATED_VIEW_TYPE, {viewType: fileSuffix});
+		context.addLintingMessage(resource.getPath(), {id: MESSAGE.DEPRECATED_VIEW_TYPE, args: {viewType: fileSuffix}});
 	});
 }

--- a/src/linter/html/HtmlReporter.ts
+++ b/src/linter/html/HtmlReporter.ts
@@ -50,7 +50,7 @@ export default class HtmlReporter {
 			column: startPos.character + 1,
 		};
 
-		this.#context.addLintingMessage(this.#resourcePath, id, args, position, fix);
+		this.#context.addLintingMessage(this.#resourcePath, {id, args, position, fix});
 	}
 
 	addCoverageInfo({node, message, category}: ReporterCoverageInfo) {

--- a/src/linter/html/transpiler.ts
+++ b/src/linter/html/transpiler.ts
@@ -56,7 +56,7 @@ export default async function transpileHtml(
 		return {source: "", map: ""};
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
-		context.addLintingMessage(resourcePath, MESSAGE.PARSING_ERROR, {message});
+		context.addLintingMessage(resourcePath, {id: MESSAGE.PARSING_ERROR, args: {message}});
 		return;
 	}
 }

--- a/src/linter/lintWorkspace.ts
+++ b/src/linter/lintWorkspace.ts
@@ -131,7 +131,7 @@ async function runAutofix(
 			rawMessages.forEach((msg) => {
 				if (msg.id === MESSAGE.AUTOFIX_ERROR) {
 					context.addLintingMessage(
-						filePath, msg.id, (msg as RawLintMessage<MESSAGE.AUTOFIX_ERROR>).args);
+						filePath, {id: msg.id, args: (msg as RawLintMessage<MESSAGE.AUTOFIX_ERROR>).args});
 				}
 				if (msg.id === MESSAGE.PARSING_ERROR) {
 					const parsingError = msg as RawLintMessage<MESSAGE.PARSING_ERROR>;
@@ -151,7 +151,7 @@ async function runAutofix(
 						return msg.args.message === parsingError.args.message && positionMatch;
 					});
 					if (!isDuplicate) {
-						context.addLintingMessage(filePath, msg.id, parsingError.args); // No position
+						context.addLintingMessage(filePath, {id: msg.id, args: parsingError.args}); // No position
 					}
 				}
 			});

--- a/src/linter/lintWorkspace.ts
+++ b/src/linter/lintWorkspace.ts
@@ -148,7 +148,7 @@ async function runAutofix(
 						} else {
 							positionMatch = !msg.position && !parsingError.position;
 						}
-						return msg.args.message === parsingError.args.message && positionMatch;
+						return msg.args?.message === parsingError.args?.message && positionMatch;
 					});
 					if (!isDuplicate) {
 						context.addLintingMessage(filePath, {id: msg.id, args: parsingError.args}); // No position

--- a/src/linter/manifestJson/ManifestLinter.ts
+++ b/src/linter/manifestJson/ManifestLinter.ts
@@ -48,7 +48,7 @@ export default class ManifestLinter {
 			this.#analyzeManifest(source.data);
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
-			this.#context.addLintingMessage(this.#resourcePath, MESSAGE.PARSING_ERROR, {message});
+			this.#context.addLintingMessage(this.#resourcePath, {id: MESSAGE.PARSING_ERROR, args: {message}});
 		}
 	}
 

--- a/src/linter/manifestJson/ManifestReporter.ts
+++ b/src/linter/manifestJson/ManifestReporter.ts
@@ -38,7 +38,7 @@ export default class ManifestReporter {
 			args = argsOrNode;
 		}
 
-		this.#context.addLintingMessage(this.#resourcePath, id, args, this.#getPosition(node));
+		this.#context.addLintingMessage(this.#resourcePath, {id, args, position: this.#getPosition(node)});
 	}
 
 	addCoverageInfo({node, message, category}: ReporterCoverageInfo) {

--- a/src/linter/ui5Types/SourceFileLinter.ts
+++ b/src/linter/ui5Types/SourceFileLinter.ts
@@ -147,7 +147,8 @@ export default class SourceFileLinter {
 			if (err instanceof Error) {
 				log.verbose(`Call stack: ${err.stack}`);
 			}
-			this.typeLinter.getContext().addLintingMessage(this.resourcePath, MESSAGE.PARSING_ERROR, {message});
+			this.typeLinter.getContext().addLintingMessage(this.resourcePath,
+				{id: MESSAGE.PARSING_ERROR, args: {message}});
 		}
 	}
 

--- a/src/linter/ui5Types/asyncComponentFlags.ts
+++ b/src/linter/ui5Types/asyncComponentFlags.ts
@@ -377,9 +377,11 @@ function reportUiComponentResults({
 				const {key: posInfo} = pointers[pointerKey];
 				context.addLintingMessage(
 					resourcePath.replace(componentFileName, "manifest.json"),
-					MESSAGE.COMPONENT_REDUNDANT_ASYNC_FLAG,
-					{asyncFlagLocation: pointerKey},
-					posInfo
+					{
+						id: MESSAGE.COMPONENT_REDUNDANT_ASYNC_FLAG,
+						args: {asyncFlagLocation: pointerKey},
+						position: posInfo,
+					}
 				);
 			} else {
 				reporter.addMessage(MESSAGE.COMPONENT_REDUNDANT_ASYNC_FLAG, {

--- a/src/linter/xmlTemplate/Parser.ts
+++ b/src/linter/xmlTemplate/Parser.ts
@@ -351,11 +351,13 @@ export default class Parser {
 		} else if (namespace === SVG_NAMESPACE) {
 			// Ignore SVG nodes
 			this.#context.addLintingMessage(this.#resourcePath,
-				MESSAGE.SVG_IN_XML,
-				undefined as never,
 				{
-					line: tag.openStart.line + 1, // Add one to align with IDEs
-					column: tag.openStart.character + 1,
+					id: MESSAGE.SVG_IN_XML,
+					args: undefined as never,
+					position: {
+						line: tag.openStart.line + 1, // Add one to align with IDEs
+						column: tag.openStart.character + 1,
+					},
 				}
 			);
 			return {
@@ -368,11 +370,13 @@ export default class Parser {
 		} else if (namespace === XHTML_NAMESPACE) {
 			// Ignore XHTML nodes for now
 			this.#context.addLintingMessage(this.#resourcePath,
-				MESSAGE.HTML_IN_XML,
-				undefined as never,
 				{
-					line: tag.openStart.line + 1, // Add one to align with IDEs
-					column: tag.openStart.character + 1,
+					id: MESSAGE.HTML_IN_XML,
+					args: undefined as never,
+					position: {
+						line: tag.openStart.line + 1, // Add one to align with IDEs
+						column: tag.openStart.character + 1,
+					},
 				}
 			);
 			return {
@@ -444,8 +448,10 @@ export default class Parser {
 						if (requireDeclarations.length) {
 							// Usage of space separated list is not recommended, as it only allows for global access
 							this.#context.addLintingMessage(this.#resourcePath,
-								MESSAGE.NO_LEGACY_TEMPLATE_REQUIRE_SYNTAX,
-								{moduleNames: attr.value}, attr.start
+								{
+									id: MESSAGE.NO_LEGACY_TEMPLATE_REQUIRE_SYNTAX,
+									args: {moduleNames: attr.value}, position: attr.start,
+								}
 							);
 						}
 					} else {
@@ -638,9 +644,9 @@ export default class Parser {
 								// and there is no easy way to know whether the input is intended to be a binding or
 								// event handler.
 								this.#context.addLintingMessage(
-									this.#resourcePath, MESSAGE.PARSING_ERROR, {
+									this.#resourcePath, {id: MESSAGE.PARSING_ERROR, args: {
 										message: err instanceof Error ? err.message : String(err),
-									}, position
+									}, position}
 								);
 								return;
 							}
@@ -683,15 +689,18 @@ export default class Parser {
 							// Note that this could also be a global function reference, but we can't distinguish
 							// that here.
 							this.#context.addLintingMessage(
-								this.#resourcePath, MESSAGE.NO_AMBIGUOUS_EVENT_HANDLER, {
-									eventHandler: functionName,
-								}, position
+								this.#resourcePath, {
+									id: MESSAGE.NO_AMBIGUOUS_EVENT_HANDLER,
+									args: {eventHandler: functionName},
+									position,
+								}
 							);
 						} else {
-							this.#context.addLintingMessage(this.#resourcePath, MESSAGE.NO_GLOBALS, {
-								variableName,
-								namespace: functionName,
-							}, position);
+							this.#context.addLintingMessage(this.#resourcePath, {
+								id: MESSAGE.NO_GLOBALS,
+								args: {variableName, namespace: functionName},
+								position,
+							});
 						}
 					});
 

--- a/src/linter/xmlTemplate/Parser.ts
+++ b/src/linter/xmlTemplate/Parser.ts
@@ -353,7 +353,6 @@ export default class Parser {
 			this.#context.addLintingMessage(this.#resourcePath,
 				{
 					id: MESSAGE.SVG_IN_XML,
-					args: undefined as never,
 					position: {
 						line: tag.openStart.line + 1, // Add one to align with IDEs
 						column: tag.openStart.character + 1,
@@ -372,7 +371,6 @@ export default class Parser {
 			this.#context.addLintingMessage(this.#resourcePath,
 				{
 					id: MESSAGE.HTML_IN_XML,
-					args: undefined as never,
 					position: {
 						line: tag.openStart.line + 1, // Add one to align with IDEs
 						column: tag.openStart.character + 1,

--- a/src/linter/xmlTemplate/transpiler.ts
+++ b/src/linter/xmlTemplate/transpiler.ts
@@ -28,7 +28,7 @@ export default async function transpileXml(
 		return res;
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
-		context.addLintingMessage(resourcePath, MESSAGE.PARSING_ERROR, {message});
+		context.addLintingMessage(resourcePath, {id: MESSAGE.PARSING_ERROR, args: {message}});
 	}
 }
 

--- a/src/linter/yaml/YamlLinter.ts
+++ b/src/linter/yaml/YamlLinter.ts
@@ -54,7 +54,7 @@ export default class YamlLinter {
 			});
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
-			this.#context.addLintingMessage(this.#resourcePath, MESSAGE.PARSING_ERROR, {message});
+			this.#context.addLintingMessage(this.#resourcePath, {id: MESSAGE.PARSING_ERROR, args: {message}});
 		}
 	}
 
@@ -71,13 +71,15 @@ export default class YamlLinter {
 				const positionInfo = getPosition(lib);
 				this.#context.addLintingMessage(
 					this.#resourcePath,
-					MESSAGE.DEPRECATED_LIBRARY,
 					{
-						libraryName,
-					},
-					{
-						line: positionInfo.start.line + offset,
-						column: positionInfo.start.column,
+						id: MESSAGE.DEPRECATED_LIBRARY,
+						args: {
+							libraryName,
+						},
+						position: {
+							line: positionInfo.start.line + offset,
+							column: positionInfo.start.column,
+						},
 					}
 				);
 			}

--- a/test/lib/linter/LinterContext.ts
+++ b/test/lib/linter/LinterContext.ts
@@ -18,13 +18,13 @@ test.before((t) => {
 
 	// Propagate with findings in every 10th row up to 100
 	for (let i = 1; i <= 10; i++) {
-		t.context.linterContext.addLintingMessage("/foo.js", MESSAGE.DEPRECATED_API_ACCESS, {
+		t.context.linterContext.addLintingMessage("/foo.js", {id: MESSAGE.DEPRECATED_API_ACCESS, args: {
 			apiName: "foo",
 			details: "bar",
-		}, {
+		}, position: {
 			line: i * 10,
 			column: 10,
-		});
+		}});
 	}
 });
 


### PR DESCRIPTION
This change aims to align the signature of `addLintingMessage` and `addLintingMessages`. The core change is that now `addLintingMessage` supports `fix` and `ui5Types` arguments