### PR TITLE
refactor(Bootstrap Attributes): Remove unnecessary condition

### DIFF
--- a/src/linter/html/fix/RemoveAttributeFix.ts
+++ b/src/linter/html/fix/RemoveAttributeFix.ts
@@ -64,16 +64,6 @@ export default class RemoveAttributeFix extends HtmlFix {
 			}
 		}
 
-		// This if statement is a workaround for edge cases
-		// since sax-wasm parses wrong positions for NoValue single-character attributes.
-		// TODO: Remove once it's fixed (https://github.com/justinwilaby/sax-wasm/issues/139).
-		if (previousAttr && previousAttr.type === AttributeType.NoValue && previousAttr.name.value.length === 1) {
-			startPos = {
-				line: previousAttr.name.start.line,
-				character: previousAttr.name.start.character + 1,
-			};
-		}
-
 		// Edge case: no space w/ NoValues or NoQuotes
 		const edgeCaseStart = this._getEdgeCaseStartPos(tag, previousAttr, attr, subsequentAttr);
 		if (edgeCaseStart) {
@@ -111,16 +101,6 @@ export default class RemoveAttributeFix extends HtmlFix {
 					character: attr.name.end.character,
 				};
 				break;
-		}
-
-		// This if statement is a workaround for edge cases
-		// since sax-wasm parses wrong positions for NoValue single-character attributes.
-		// TODO: Remove once it's fixed (https://github.com/justinwilaby/sax-wasm/issues/139).
-		if (attr.type === AttributeType.NoValue && attr.name.value.length === 1) {
-			endPos = {
-				line: attr.name.start.line,
-				character: attr.name.start.character + 1,
-			};
 		}
 
 		if (!endPos) {

--- a/src/linter/html/fix/RenameAttributeFix.ts
+++ b/src/linter/html/fix/RenameAttributeFix.ts
@@ -1,4 +1,4 @@
-import {Attribute, AttributeType, PositionDetail} from "sax-wasm";
+import {Attribute, PositionDetail} from "sax-wasm";
 import {ChangeAction, ChangeSet} from "../../../utils/textChanges.js";
 import {HtmlFix} from "./HtmlFix.js";
 import {ToPositionCallback} from "../../ui5Types/fix/XmlEnabledFix.js";
@@ -16,16 +16,6 @@ export default class RenameAttributeFix extends HtmlFix {
 		super();
 		this.startPositionDetail = attribute.name.start;
 		this.endPositionDetail = attribute.name.end;
-
-		// This if statement is a workaround for edge cases
-		// since sax-wasm parses wrong positions for NoValue single-character attributes.
-		// TODO: Remove once it's fixed (https://github.com/justinwilaby/sax-wasm/issues/139).
-		if (attribute.type === AttributeType.NoValue && attribute.name.value.length === 1) {
-			this.endPositionDetail = {
-				line: attribute.name.start.line,
-				character: attribute.name.start.character + 1,
-			};
-		}
 	}
 
 	calculateSourceCodeRange(toPosition: ToPositionCallback) {


### PR DESCRIPTION
Before this change, there were workarounds for edge cases because "sax-wasm" was broken.

The package got updated, so this code can safely be removed (unit tests cover it [1](https://github.com/UI5/linter/blob/9a05dd3a810ef64b2c2eee6ff10e0bcc22fbcae2/test/lib/linter/html/fix/RemoveAttributeFix.ts#L401) [2](https://github.com/UI5/linter/blob/9a05dd3a810ef64b2c2eee6ff10e0bcc22fbcae2/test/lib/linter/html/fix/RenameAttributeFix.ts#L417) ).