### PR TITLE
ci(github-actions): Ignore Coveralls errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,9 @@ jobs:
     - name: Perform build
       run: npm run build-test
 
-    # - name: Run unit tests
-    #   run: npm run coverage
+    - name: Run unit tests
+      run: npm run coverage
 
     - name: Send report to Coveralls for package @ui5/linter
       uses: coverallsapp/github-action@v2.3.6
-
-    - name: Should still pass
-      run: echo "If we reached this step, everything went well!"
+      continue-on-error: true # Do not fail the job if coverage reporting fails (e.g. service is down)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,14 +36,12 @@ jobs:
     - name: Perform build
       run: npm run build-test
 
-    - name: Run unit tests
-      run: npm run coverage
+    # - name: Run unit tests
+    #   run: npm run coverage
 
-    - name: Send report to Coveralls for package @ui5/linter (TEST - WILL FAIL)
+    - name: Send report to Coveralls for package @ui5/linter
       uses: coverallsapp/github-action@v2.3.6
       continue-on-error: true
-      with:
-        github-token: invalid-token-to-test-failure
 
-    - name: Test step after Coveralls (should execute even if Coveralls fails)
-      run: echo "This step executed successfully after Coveralls step"
+    - name: Should still pass
+      run: echo "If we reached this step, everything went well!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
 
     - name: Send report to Coveralls for package @ui5/linter
       uses: coverallsapp/github-action@v2.3.6
-      continue-on-error: true
 
     - name: Should still pass
       run: echo "If we reached this step, everything went well!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,5 +39,11 @@ jobs:
     - name: Run unit tests
       run: npm run coverage
 
-    - name: Send report to Coveralls for package @ui5/linter
+    - name: Send report to Coveralls for package @ui5/linter (TEST - WILL FAIL)
       uses: coverallsapp/github-action@v2.3.6
+      continue-on-error: true
+      with:
+        github-token: invalid-token-to-test-failure
+
+    - name: Test step after Coveralls (should execute even if Coveralls fails)
+      run: echo "This step executed successfully after Coveralls step"


### PR DESCRIPTION
This will add `continue-on-error` to the Coveralls report upload step in the job "CI / General checks...".
In case of an error with this step (e.g. the Coveralls service is temporarily down) the job continues as normal and does NOT fail.